### PR TITLE
Added initialization call to the mutex

### DIFF
--- a/jni/mutex.c
+++ b/jni/mutex.c
@@ -43,6 +43,7 @@ JNIEXPORT void JNICALL Java_eu_codlab_sharedmutex_Mutex_configure(JNIEnv* env, j
 
     des_mutex = shmget(IPC_PRIVATE, sizeof(*semaphor), mode);
     semaphor = shmat(des_mutex, NULL, 0);
+    pthread_mutex_init(semaphor, NULL);
 
     sleep(1);
 


### PR DESCRIPTION
Although shmget clears the shared memory region automatically, and a zeroed-out semaphore is a valid state for a semaphore to be in, it's good practice to include the initialization call.
